### PR TITLE
Fix update check was always checking.

### DIFF
--- a/src/Kaleidoscope/Heatmap.cpp
+++ b/src/Kaleidoscope/Heatmap.cpp
@@ -96,7 +96,7 @@ Heatmap::loopHook(bool is_post_clear) {
 
 void
 Heatmap::update(void) {
-  if (end_time_ && (millis() > end_time_))
+  if (end_time_ && (millis() < end_time_))
     return;
 
   end_time_ = millis() + update_delay;


### PR DESCRIPTION
LED update should happen when the timer is past the end_time_, not it is
less than the end_time_.

fixes #4 