### PR TITLE
Implement Heatmap Reset Method

### DIFF
--- a/src/Kaleidoscope/Heatmap.cpp
+++ b/src/Kaleidoscope/Heatmap.cpp
@@ -111,6 +111,18 @@ void Heatmap::shiftStats(void) {
   highest_ = highest_ >> 1;
 }
 
+void Heatmap::resetMap(void) {
+  // this method can be used as a way to work around an existing bug with a single key 
+  // getting special attention or if the user just wants a button to reset the map
+  for (uint8_t r = 0; r < ROWS; r++) {
+    for (uint8_t c = 0; c < COLS; c++) {
+      heatmap_[r][c] = 0;
+    }
+  }
+
+  highest_ = 1;
+}
+
 void Heatmap::setup(void) {
   Kaleidoscope.useEventHandlerHook(eventHook);
   Kaleidoscope.useLoopHook(loopHook);

--- a/src/Kaleidoscope/Heatmap.h
+++ b/src/Kaleidoscope/Heatmap.h
@@ -29,6 +29,7 @@ class Heatmap : public LEDMode {
   static uint16_t update_delay;
   static const cRGB *heat_colors;
   static uint8_t heat_colors_length;
+  void resetMap(void);
 
  protected:
   void setup(void) final;


### PR DESCRIPTION
This commit includes the resetMap method which is used to start the heatmap from 0. I also use it as a workaround for my map starting up with an "infinitely hot" key